### PR TITLE
Update CI 02 2025 

### DIFF
--- a/.github/conan_linux_build/action.yml
+++ b/.github/conan_linux_build/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: "g++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 10]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++"
@@ -38,8 +38,8 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
+        pip install conan~=1.66.0
         pip install wheel
-        pip install conan~=1.64.0
         # pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         # The following is only for the self-hosted M1 with the x64 brew

--- a/.github/conan_linux_build/action.yml
+++ b/.github/conan_linux_build/action.yml
@@ -39,9 +39,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install conan~=1.66.0
-        pip install wheel
-        # pip install "markupsafe<2.1"
-        pip install -Iv cmake>=3.17
+
         # The following is only for the self-hosted M1 with the x64 brew
         pip install h5py
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "
@@ -35,8 +35,8 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
+        pip install conan~=1.66.0
         pip install wheel
-        pip install conan~=1.64.0
         # pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         # The following is only for the self-hosted M1 with the x64 brew

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -36,9 +36,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install conan~=1.66.0
-        pip install wheel
-        # pip install "markupsafe<2.1"
-        pip install -Iv cmake>=3.17
+
         # The following is only for the self-hosted M1 with the x64 brew
         pip install h5py
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi

--- a/.github/conan_selfhosted_m1_build/action.yml
+++ b/.github/conan_selfhosted_m1_build/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -54,7 +54,6 @@ runs:
       run: |
         for /f "delims=" %%i in ('where cmake') do set CONAN_CMAKE_PROGRAM="%%i"
         set CONAN_USER_HOME=%cd%\_conan
-        set VS160COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools"
 
         echo Add LKEB artifactory as remote at URL: %CONAN_UPLOAD%
         conan remote add %CONAN_LKEB_ARTIFACTORY% %CONAN_UPLOAD%

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -24,9 +24,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install conan~=1.66.0
-        pip install wheel
-        pip install "markupsafe<2.1"
-        pip install -Iv cmake==3.21
+
         pip install h5py
 
         REM Fish the package name from the conanfile.py

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Windows,
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-visual-version:
-    description: "MSVC version: 15, 16 represent msvc-2017 or msvc-2019"
+    description: "MSVC version: 16, 17 represent msvc-2019 and msvc-2022"
     required: true
   conan-visual-runtime:
     description: "MD or MDd"
@@ -23,8 +23,8 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
+        pip install conan~=1.66.0
         pip install wheel
-        pip install conan~=1.64.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake==3.21
         pip install h5py

--- a/.github/workflows/conanpackage.yml
+++ b/.github/workflows/conanpackage.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -86,13 +86,6 @@ jobs:
         with:
           python-version: "3.11"
           architecture: x64
-
-      - name: Setup gcc for Linux
-        if: startsWith(runner.os, 'Linux')
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: ${{matrix.build-cversion}}
-          platform: x64
 
       - name: Windows build
         if: startsWith(runner.os, 'Windows')

--- a/.github/workflows/conanpackage.yml
+++ b/.github/workflows/conanpackage.yml
@@ -25,22 +25,6 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-          # - name: Linux_gcc9
-          #  os: ubuntu-20.04
-          #  build-compiler: gcc
-          #  build-cversion: 9
-          #  build-config: Release
-          #  build-os: Linux
-          #  build-libcxx: libstdc++
-
-          - name: Linux_gcc10
-            os: ubuntu-20.04
-            build-compiler: gcc
-            build-cversion: 10
-            build-config: Release
-            build-os: Linux
-            build-libcxx: libstdc++11
-
           - name: Linux_gcc11
             os: ubuntu-22.04
             build-compiler: gcc
@@ -56,15 +40,6 @@ jobs:
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++11
-
-          - name: Macos_xcode13.4
-            os: macos-12
-            build-compiler: apple-clang
-            build-cversion: 13
-            build-config: Release
-            build-os: Macos
-            build-xcode-version: 13.4
-            build-libcxx: libc++
 
           - name: Macos_xcode14.3
             os: macos-13
@@ -82,6 +57,15 @@ jobs:
             build-config: Release
             build-os: Macos
             build-xcode-version: 15.4
+            build-libcxx: libc++
+
+          - name: Macos_xcode16
+            os: macos-15
+            build-compiler: apple-clang
+            build-cversion: 16
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 16.2
             build-libcxx: libc++
 
     steps:

--- a/conanfile.py
+++ b/conanfile.py
@@ -176,7 +176,14 @@ class HDF5Conan(ConanFile):
         tc.variables["TGZPATH"] = "${CMAKE_SOURCE_DIR}/../"
         tc.variables["HDF5_ENABLE_DEBUG_APIS"] = "OFF"
         tc.variables["HDF_PACKAGE_NAMESPACE"] = "hdf5::"
-        
+
+        tc.variables["HDF5_BUILD_EXAMPLES"] = "OFF"
+        tc.variables["HDF5_BUILD_UTILS"] = "OFF"
+        tc.variables["HDF5_BUILD_TOOLS"] = "OFF"
+        tc.variables["HDF5_ENABLE_EMBEDDED_LIBINFO"] = "OFF"
+        tc.variables["HDF5_ENABLE_HSIZET"] = "OFF"
+        tc.variables["HDF5_PACKAGE_EXTLIBS"] = "ON"
+
         # Using an external zlib
         if self.options.with_zlib:
             
@@ -197,20 +204,12 @@ class HDF5Conan(ConanFile):
             tc.variables["ZLIB_PACKAGE_NAME"] = "zlib"
              
 
-        tc.variables["HDF5_BUILD_EXAMPLES"] = "OFF"
-        tc.variables["HDF5_BUILD_UTILS"] = "OFF"
-        tc.variables["HDF5_BUILD_TOOLS"] = "OFF"
-        tc.variables["HDF5_ENABLE_EMBEDDED_LIBINFO"] = "OFF"
-        tc.variables["HDF5_ENABLE_HSIZET"] = "OFF"
-        tc.variables["HDF5_PACKAGE_EXTLIBS"] = "ON"
-        # tc.variables["PREFIX"] = "hdf5"
-        # tc.variables["HDF5_PREFIX"] = "hdf5"
-
         #if self.settings.compiler == "Visual Studio":
         tc.variables["CMAKE_DEBUG_POSTFIX"] = "_d"
-        tc.variables[
-            "CMAKE_MSVC_RUNTIME_LIBRARY"
-        ] = "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
+        tc.variables["CMAKE_INSTALL_PREFIX"] = str(
+            Path(self.build_folder, "install").as_posix()
+        )
+        tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release"
 
         # Make sure all paths are Posix to avoid escape character issues
         if self.settings.os == "Macos":
@@ -218,13 +217,6 @@ class HDF5Conan(ConanFile):
                 Path(self.build_folder, "lib").as_posix()
             )
             self.output.info("cmake build: %s" % self.build_folder)
-
-        tc.variables["CMAKE_TOOLCHAIN_FILE"] = "conan_toolchain.cmake"
-        tc.variables["CMAKE_INSTALL_PREFIX"] = str(
-            Path(self.build_folder, "install").as_posix()
-        )
-
-        tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release"
 
         if self.settings.os == "Windows":
             tc.variables["CMAKE_CXX_FLAGS"] = tc.variables.get("CMAKE_CXX_FLAGS", "") + "/DWIN32 /EHsc /MP /permissive- /Zc:__cplusplus"


### PR DESCRIPTION
- Remove `ubuntu-20.04`
- Remove `macos-12`
- Add `macos-15` (XCode 16.2)

See https://github.com/actions/runner-images/issues/10721
> The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and by 01/13/25 for ADO

See https://github.com/actions/runner-images/issues/11101
> The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01 

Also: update conan to [1.66 which adds new apple-clang 16](https://github.com/conan-io/conan/releases/tag/1.66.0) (Otherwise adding `macos-15` (XCode 16.2) won't compile)
- **Caution**: I think this will require downstream repos (i.e. HDF5 loader in ManiVault) to also upgrade their conan version